### PR TITLE
Add playbook snippet to Feature Flags docs

### DIFF
--- a/docs/otel/feature-flags.md
+++ b/docs/otel/feature-flags.md
@@ -1,26 +1,26 @@
 # Feature Flags
 
-This guide has three tracks:
+Adding OpenTelemetry spans to your feature flags implementation provides a **clear connection between the code, your product and engineering teams, and what your customers are seeing in production**. The full context from OpenTelemetry removes the mystery when managing your deployments and customer experience.
 
-| Track | Difficulty |
-| ----- | ----- |
-| [Add new telemetry to your feature flag SDK or library](#) | 🛠 🛠 🛠 |
+| What are you looking to do? | 
+| ----- | 
+| [Add new telemetry to your feature flag SDK or library](#add-new-instrumention-to-your-sdk-or-library) |
+| [See example integrations](#example-integrations) |
 
 ## Add New Instrumention to your SDK or library
 
-### Design
-
-* Determine if there are OpenTelemetry SDK(s) available for the language(s) your SDK or library is written in.
-
 ### Instrument
 
-* Start coding! Import the language-specific OpenTelemetry API into your product and use it to generate metrics, logs, and traces.
+1. Determine if there are OpenTelemetry SDK(s) available for the language(s) your SDK or library is written in.
+2. Start coding! Import the language-specific OpenTelemetry API into your product and use it to generate metrics, logs, and traces.
 
 ### Run
 
 * Send data from your product to an OpenTelemetry collector that outputs to the console and verify output.
 
-### Example Integrations
+<br/>
+
+## Example Integrations
 
 > These example solutions use plugins to generate metrics, logs or traces by automatically-instrumenting Javascript libaries or frameworks. No change to the underlying library or framework is needed.
 


### PR DESCRIPTION
* Added snippet from the deployment playbook to explain the "why" adding instrumentation will add value
* Changed formatting a bit to align to the Errors page