### PR TITLE
[proposal] add ls-info.Query to stream alert webhook payload

### DIFF
--- a/examples/webhooks/stream-webhook.json
+++ b/examples/webhooks/stream-webhook.json
@@ -87,7 +87,8 @@
         "Actual Value": {
           "ActualValue": "3.981549s"
         },
-        "Expression": "p99 is above 100ms over the last 2.0m"
+        "Expression": "p99 is above 100ms over the last 2.0m",
+        "Query": "service IN (\"android\", \"apache\", \"iOS\")"
       },
       "custom-data": {}
     }


### PR DESCRIPTION
this PR proposes a json format for alert queries in the stream alert webhook payload

this is just a string matching this subheader we show in the UI:

![image](https://user-images.githubusercontent.com/5599894/137798797-9c94aaff-9888-42eb-9f25-e2a22d63da73.png)

it could be copy-pasted into the explorer query bar and run as is