### PR TITLE
Add metric shapes

### DIFF
--- a/collector/generatorreceiver/internal/generator/trace_generator.go
+++ b/collector/generatorreceiver/internal/generator/trace_generator.go
@@ -67,26 +67,33 @@ func (g *TraceGenerator) Generate(startTimeMicros int64) *pdata.Traces {
 }
 
 func (g *TraceGenerator) shouldCreateTagSet(ts topology.TagSet) bool {
+	// TODO: I'm changing this to not panic if the flag doesn't exist,
+	// and act as though it's unset, but we might want some kind of
+	// validation instead.
 	if len(ts.FlagSet) > 0 {
 		f := g.flagManager.GetFlag(ts.FlagSet)
-		return f.Enabled()
+		return f != nil && f.Enabled()
 	} else if len(ts.FlagUnset) > 0 {
 		f := g.flagManager.GetFlag(ts.FlagUnset)
-		return !f.Enabled()
+		return !(f != nil && f.Enabled())
 	}
 	return true
 }
 
 func (g *TraceGenerator) shouldCreateSpanForRoute(serviceTier *topology.ServiceTier, r string) bool {
+	// TODO: I'm changing this to not panic if the flag doesn't exist,
+	// and act as though it's unset, but we might want some kind of
+	// validation instead.
+
 	// TODO: multiple routes with the same name not supported
 	route := serviceTier.GetRoute(r)
 
 	if len(route.FlagSet) > 0 {
 		f := g.flagManager.GetFlag(route.FlagSet)
-		return f.Enabled()
+		return f != nil && f.Enabled()
 	} else if len(route.FlagUnset) > 0 {
 		f := g.flagManager.GetFlag(route.FlagUnset)
-		return !f.Enabled()
+		return !(f != nil && f.Enabled())
 	}
 	return true
 }

--- a/collector/generatorreceiver/internal/topology/metric.go
+++ b/collector/generatorreceiver/internal/topology/metric.go
@@ -7,6 +7,16 @@ import (
 )
 
 const DefaultPeriod = 60 * time.Minute
+const DefaultOffset = 0 * time.Minute
+
+type Shape string
+
+const (
+	Sine     Shape = "sine"
+	Sawtooth Shape = "sawtooth"
+	Square   Shape = "square"
+	Triangle Shape = "triangle"
+)
 
 type Metric struct {
 	Name      string         `json:"name" yaml:"name"`
@@ -14,10 +24,30 @@ type Metric struct {
 	Min       float64        `json:"min" yaml:"min"`
 	Max       float64        `json:"max" yaml:"max"`
 	Period    *time.Duration `json:"period" yaml:"period"`
+	Offset    *time.Duration `json:"offset" yaml:"offset"`
 	FlagSet   string         `json:"flag_set" yaml:"flag_set"`
 	FlagUnset string         `json:"flag_unset" yaml:"flag_unset"`
 	Tags      map[string]string
-	// TODO: add "shape"
+	Shape     Shape `json:"shape" yaml:"shape"`
+}
+
+func SineValue(phase float64) float64 {
+	return (math.Sin(2*math.Pi*phase) + 1) / 2
+}
+
+func SawtoothValue(phase float64) float64 {
+	return phase
+}
+
+func SquareValue(phase float64) float64 {
+	if phase < 0.5 {
+		return 0.0
+	}
+	return 1.0
+}
+
+func TriangleValue(phase float64) float64 {
+	return 1.0 - 2.0*math.Abs(0.5-phase)
 }
 
 func (m *Metric) GetValue() float64 {
@@ -25,23 +55,43 @@ func (m *Metric) GetValue() float64 {
 		period := DefaultPeriod
 		m.Period = &period
 	}
+	if m.Offset == nil {
+		offset := DefaultOffset
+		m.Offset = &offset
+	}
 
-	now := time.Now()
+	now := time.Now().Add(-*m.Offset)
 	since := now.Sub(now.Truncate(*m.Period))
 	phase := float64(since) / float64(*m.Period)
-	sin := math.Sin(2 * math.Pi * phase)
-	return m.Min + (m.Max-m.Min)*(sin+1)/2
+
+	factor := func(phase float64) float64 {
+		switch m.Shape {
+		case Sine:
+			return SineValue(phase)
+		case Sawtooth:
+			return SawtoothValue(phase)
+		case Square:
+			return SquareValue(phase)
+		case Triangle:
+			return TriangleValue(phase)
+		default:
+			// TODO: what would be a reasonable default? Maybe just sine?
+			return 0.5
+		}
+	}(phase)
+
+	return m.Min + (m.Max-m.Min)*factor
 }
 
 func (m *Metric) ShouldGenerate(fm *flags.FlagManager) bool {
 	// TODO: use the set flag's _value_... somehow
 	if m.FlagSet != "" {
-		if set := fm.GetFlag(m.FlagSet); !set.Enabled() {
+		if set := fm.GetFlag(m.FlagSet); !(set != nil && set.Enabled()) {
 			return false
 		}
 	}
 	if m.FlagUnset != "" {
-		if unset := fm.GetFlag(m.FlagUnset); unset.Enabled() {
+		if unset := fm.GetFlag(m.FlagUnset); unset != nil && unset.Enabled() {
 			return false
 		}
 	}

--- a/collector/generatorreceiver/topos/hipster_shop.yaml
+++ b/collector/generatorreceiver/topos/hipster_shop.yaml
@@ -31,6 +31,7 @@ topology:
           max: 10000
           min: 1000
           period: 2m
+          shape: sawtooth
           flag_set: frontend_errors
           tags:
             something: bad


### PR DESCRIPTION
This defines a few shapes for metric behavior:
- sine (already existed; still the default)
- sawtooth
- square
- triangle

Also adds an "offset" parameter to complement "period".

Unrelatedly, changes a few uses of `Flag.Enabled()` to check first if the flag exists. A nonexistent flag is considered unset. This prevents a panic when trying to reference undefined flags in the yaml. There's better approaches, but this one was quick :)