### PR TITLE
support for generating k8s cpu metrics

### DIFF
--- a/collector/generatorreceiver/generator_receiver.go
+++ b/collector/generatorreceiver/generator_receiver.go
@@ -70,6 +70,11 @@ func (g generatorReceiver) Start(ctx context.Context, host component.Host) error
 
 	if g.metricConsumer != nil {
 		for _, s := range topoFile.Topology.Services {
+			k8sMetrics := s.Kubernetes.GenerateMetrics(s)
+			if k8sMetrics != nil {
+				s.Metrics = append(s.Metrics, k8sMetrics...)
+			}
+
 			for _, m := range s.Metrics {
 				metricTicker := time.NewTicker(1 * time.Second)
 				g.tickers = append(g.tickers, metricTicker)

--- a/collector/generatorreceiver/generator_receiver.go
+++ b/collector/generatorreceiver/generator_receiver.go
@@ -69,11 +69,11 @@ func (g generatorReceiver) Start(ctx context.Context, host component.Host) error
 	}
 
 	for _, s := range topoFile.Topology.Services {
-		for _, resource := range s.ResourceAttributeSets {
-			resource.Kubernetes.CreatePod(s)
+		for i := range s.ResourceAttributeSets {
+			s.ResourceAttributeSets[i].Kubernetes.CreatePod(s)
 
-			for k, v := range resource.Kubernetes.GetK8sTags() {
-				resource.ResourceAttributes[k] = v
+			for k, v := range s.ResourceAttributeSets[i].Kubernetes.GetK8sTags() {
+				s.ResourceAttributeSets[i].ResourceAttributes[k] = v
 			}
 		}
 	}

--- a/collector/generatorreceiver/generator_receiver.go
+++ b/collector/generatorreceiver/generator_receiver.go
@@ -91,6 +91,12 @@ func (g generatorReceiver) Start(ctx context.Context, host component.Host) error
 				// For each resource generate k8s metrics if enabled
 				k8sMetrics := resource.Kubernetes.GenerateMetrics(s)
 				if k8sMetrics != nil {
+
+					for i := range k8sMetrics {
+						// keep the same flags as the resources.
+						k8sMetrics[i].EmbeddedFlags = resource.EmbeddedFlags
+					}
+
 					effectiveMetrics = append(effectiveMetrics, k8sMetrics...)
 				}
 			}

--- a/collector/generatorreceiver/internal/generator/trace_generator.go
+++ b/collector/generatorreceiver/internal/generator/trace_generator.go
@@ -81,11 +81,10 @@ func (g *TraceGenerator) createSpanForServiceRouteCall(traces *pdata.Traces, ser
 
 	resource.Attributes().InsertString(string(semconv.ServiceNameKey), serviceTier.ServiceName)
 
-	resourceAttributeSet := serviceTier.GetResourceAttributeSet()
+	resourceAttributeSet := serviceTier.GetResourceAttributeSet(g.flagManager)
 	if resourceAttributeSet != nil {
-		for k, v := range resourceAttributeSet.ResourceAttributes {
-			resource.Attributes().InsertString(k, fmt.Sprintf("%v", v))
-		}
+		attrs := resource.Attributes()
+		resourceAttributeSet.ResourceAttributes.InsertTags(&attrs)
 	}
 
 	ils := rspan.InstrumentationLibrarySpans().AppendEmpty()
@@ -106,7 +105,7 @@ func (g *TraceGenerator) createSpanForServiceRouteCall(traces *pdata.Traces, ser
 			continue
 		}
 		attr := span.Attributes()
-		ts.InsertTags(&attr)
+		ts.Tags.InsertTags(&attr)
 		for _, tg := range ts.TagGenerators {
 			tg.Random = g.random
 			for k, v := range tg.GenerateTags() {

--- a/collector/generatorreceiver/internal/topology/kubernetes.go
+++ b/collector/generatorreceiver/internal/topology/kubernetes.go
@@ -111,9 +111,9 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 	return metrics
 }
 
-var letters = []rune("bcdfghjklmnpqrstvwxz2456789")
-
 func generateK8sName(n int) string {
+	var letters = []rune("bcdfghjklmnpqrstvwxz2456789")
+
 	b := make([]rune, n)
 	for i := range b {
 		b[i] = letters[rand.Intn(len(letters))]

--- a/collector/generatorreceiver/internal/topology/kubernetes.go
+++ b/collector/generatorreceiver/internal/topology/kubernetes.go
@@ -1,0 +1,99 @@
+package topology
+
+import "math/rand"
+
+type Kubernetes struct {
+	Enabled bool     `json:"enabled" yaml:"enabled"`
+	Request Resource `json:"request" yaml:"request"`
+	Limit   Resource `json:"limit" yaml:"limit"`
+	Usage   Resource `json:"usage" yaml:"usage"`
+}
+
+type Resource struct {
+	CPU    float64 `json:"cpu" yaml:"cpu"`
+	Memory float64 `json:"memory" yaml:"memory"`
+}
+
+func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
+	if !k.Enabled {
+		return nil
+	}
+
+	var metrics []Metric
+
+	replica := service.ServiceName + "-" + generateK8sName(10)
+	pod := replica + "-" + generateK8sName(5)
+
+	metrics = append(metrics, Metric{
+		Name: "kube_pod_status_phase",
+		Type: "Gauge",
+		Min:  1,
+		Max:  1,
+		Tags: map[string]string{
+			"phase": "Running",
+			"pod":   pod,
+		},
+	})
+
+	metrics = append(metrics, Metric{
+		Name: "kube_pod_owner",
+		Type: "Gauge",
+		Min:  1,
+		Max:  1,
+		Tags: map[string]string{
+			"pod":        pod,
+			"namespace":  service.ServiceName,
+			"owner_name": replica,
+			"onwer_kind": "ReplicaSet",
+		},
+	})
+
+	metrics = append(metrics, Metric{
+		Name: "kube_node_status_allocatable",
+		Type: "Gauge",
+		Min:  k.Limit.CPU * 1.2, // make the node a little bigger than the limit
+		Max:  k.Limit.CPU * 1.2, // make the node a little bigger than the limit
+		Tags: map[string]string{
+			"resource": "cpu",
+			"pod":      pod, // used to created multiple time series that will be summed up.
+		},
+	})
+
+	metrics = append(metrics, Metric{
+		Name: "kube_pod_container_resource_requests",
+		Type: "Gauge",
+		Min:  k.Request.CPU,
+		Max:  k.Request.CPU,
+		Tags: map[string]string{
+			"resource":  "cpu",
+			"namespace": service.ServiceName,
+			"container": service.ServiceName,
+			"pod":       pod,
+		},
+	})
+
+	metrics = append(metrics, Metric{
+		Name: "kube_pod_container_resource_limits",
+		Type: "Gauge",
+		Min:  k.Limit.CPU,
+		Max:  k.Limit.CPU,
+		Tags: map[string]string{
+			"resource":  "cpu",
+			"namespace": service.ServiceName,
+			"container": service.ServiceName,
+			"pod":       pod,
+		},
+	})
+
+	return metrics
+}
+
+var letters = []rune("bcdfghjklmnpqrstvwxz2456789")
+
+func generateK8sName(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/collector/generatorreceiver/internal/topology/resource_attribute_set.go
+++ b/collector/generatorreceiver/internal/topology/resource_attribute_set.go
@@ -1,6 +1,10 @@
 package topology
 
+import "github.com/lightstep/lightstep-partner-sdk/collector/generatorreceiver/internal/flags"
+
 type ResourceAttributeSet struct {
-	Weight int `json:"weight" yaml:"weight"`
-	ResourceAttributes map[string]interface{} `json:"resourceAttrs,omitempty" yaml:"resourceAttrs,omitempty"`
+	Weight              int        `json:"weight" yaml:"weight"`
+	Kubernetes          Kubernetes `json:"kubernetes" yaml:"kubernetes"`
+	ResourceAttributes  tagMap     `json:"resourceAttrs,omitempty" yaml:"resourceAttrs,omitempty"`
+	flags.EmbeddedFlags `json:",inline" yaml:",inline"`
 }

--- a/collector/generatorreceiver/internal/topology/service_route.go
+++ b/collector/generatorreceiver/internal/topology/service_route.go
@@ -7,10 +7,11 @@ import (
 )
 
 type ServiceRoute struct {
-	Route                 string                 `json:"route" yaml:"route"`
-	DownstreamCalls       map[string]string      `json:"downstreamCalls,omitempty" yaml:"downstreamCalls,omitempty"`
-	MaxLatencyMillis      int64                  `json:"maxLatencyMillis" yaml:"maxLatencyMillis"`
-	LatencyPercentiles    *LatencyPercentiles    `json:"latencyPercentiles" yaml:"latencyPercentiles"`
+	Route              string              `json:"route" yaml:"route"`
+	DownstreamCalls    map[string]string   `json:"downstreamCalls,omitempty" yaml:"downstreamCalls,omitempty"`
+	MaxLatencyMillis   int64               `json:"maxLatencyMillis" yaml:"maxLatencyMillis"`
+	LatencyPercentiles *LatencyPercentiles `json:"latencyPercentiles" yaml:"latencyPercentiles"`
+	// TODO: rename all references from `tag` to `attribute`, to follow the otel standard.
 	TagSets               []TagSet               `json:"tagSets" yaml:"tagSets"`
 	ResourceAttributeSets []ResourceAttributeSet `json:"resourceAttrSets" yaml:"resourceAttrSets"`
 	flags.EmbeddedFlags   `json:",inline" yaml:",inline"`

--- a/collector/generatorreceiver/internal/topology/service_tier.go
+++ b/collector/generatorreceiver/internal/topology/service_tier.go
@@ -1,6 +1,9 @@
 package topology
 
-import "math/rand"
+import (
+	"github.com/lightstep/lightstep-partner-sdk/collector/generatorreceiver/internal/flags"
+	"math/rand"
+)
 
 type ServiceTier struct {
 	ServiceName           string                 `json:"serviceName" yaml:"serviceName"`
@@ -8,7 +11,6 @@ type ServiceTier struct {
 	TagSets               []TagSet               `json:"tagSets" yaml:"tagSets"`
 	ResourceAttributeSets []ResourceAttributeSet `json:"resourceAttrSets" yaml:"resourceAttrSets"`
 	Metrics               []Metric               `json:"metrics" yaml:"metrics"`
-	Kubernetes            Kubernetes             `json:"kubernetes" yaml:"kubernetes"`
 	Random                *rand.Rand
 }
 
@@ -19,13 +21,24 @@ func (st *ServiceTier) GetTagSet(routeName string) []TagSet {
 	return append(tags, routeTags...)
 }
 
-func (st *ServiceTier) GetResourceAttributeSet() *ResourceAttributeSet {
+func (st *ServiceTier) GetResourceAttributeSet(fm *flags.FlagManager) *ResourceAttributeSet {
 	if len(st.ResourceAttributeSets) == 0 {
 		return nil
 	}
+	var enabledResources []ResourceAttributeSet
+	for _, resource := range st.ResourceAttributeSets {
+		if resource.ShouldGenerate(fm) {
+			enabledResources = append(enabledResources, resource)
+		}
+	}
+
+	if len(enabledResources) == 0 {
+		return nil
+	}
+
 	// TODO: also support resource attributes on routes
 	// TODO: support weight
-	return &st.ResourceAttributeSets[st.Random.Intn(len(st.ResourceAttributeSets))]
+	return &enabledResources[st.Random.Intn(len(enabledResources))]
 }
 
 func (st *ServiceTier) GetRoute(routeName string) *ServiceRoute {

--- a/collector/generatorreceiver/internal/topology/service_tier.go
+++ b/collector/generatorreceiver/internal/topology/service_tier.go
@@ -3,12 +3,13 @@ package topology
 import "math/rand"
 
 type ServiceTier struct {
-	ServiceName string `json:"serviceName" yaml:"serviceName"`
-	Routes []ServiceRoute `json:"routes" yaml:"routes"`
-	TagSets []TagSet `json:"tagSets" yaml:"tagSets"`
+	ServiceName           string                 `json:"serviceName" yaml:"serviceName"`
+	Routes                []ServiceRoute         `json:"routes" yaml:"routes"`
+	TagSets               []TagSet               `json:"tagSets" yaml:"tagSets"`
 	ResourceAttributeSets []ResourceAttributeSet `json:"resourceAttrSets" yaml:"resourceAttrSets"`
-	Metrics []Metric `json:"metrics" yaml:"metrics"`
-	Random *rand.Rand
+	Metrics               []Metric               `json:"metrics" yaml:"metrics"`
+	Kubernetes            Kubernetes             `json:"kubernetes" yaml:"kubernetes"`
+	Random                *rand.Rand
 }
 
 func (st *ServiceTier) GetTagSet(routeName string) []TagSet {

--- a/collector/generatorreceiver/internal/topology/tag_map.go
+++ b/collector/generatorreceiver/internal/topology/tag_map.go
@@ -1,6 +1,7 @@
 package topology
 
 import (
+	"fmt"
 	"go.opentelemetry.io/collector/model/pdata"
 	"strconv"
 )
@@ -22,8 +23,8 @@ func (tm *tagMap) InsertTags(attr *pdata.AttributeMap) {
 		case bool:
 			attr.InsertBool(key, val)
 		default:
-			// just insert empty string if it's an unsupported type instead of returning error (todo decide if we want error handling somewhere above this)
-			attr.InsertString(key, "")
+
+			attr.InsertString(key, fmt.Sprint(val))
 		}
 	}
 }

--- a/collector/generatorreceiver/internal/topology/tag_map.go
+++ b/collector/generatorreceiver/internal/topology/tag_map.go
@@ -1,0 +1,29 @@
+package topology
+
+import (
+	"go.opentelemetry.io/collector/model/pdata"
+	"strconv"
+)
+
+type tagMap map[string]interface{}
+
+func (tm *tagMap) InsertTags(attr *pdata.AttributeMap) {
+	for key, val := range *tm {
+		switch val := val.(type) {
+		case float64:
+			attr.InsertDouble(key, val)
+		case int:
+			attr.InsertInt(key, int64(val))
+		case string:
+			_, err := strconv.Atoi(val)
+			if err != nil {
+				attr.InsertString(key, val)
+			}
+		case bool:
+			attr.InsertBool(key, val)
+		default:
+			// just insert empty string if it's an unsupported type instead of returning error (todo decide if we want error handling somewhere above this)
+			attr.InsertString(key, "")
+		}
+	}
+}

--- a/collector/generatorreceiver/internal/topology/tag_set.go
+++ b/collector/generatorreceiver/internal/topology/tag_set.go
@@ -2,36 +2,12 @@ package topology
 
 import (
 	"github.com/lightstep/lightstep-partner-sdk/collector/generatorreceiver/internal/flags"
-	"strconv"
-
-	"go.opentelemetry.io/collector/model/pdata"
 )
 
 type TagSet struct {
-	Weight              int                    `json:"weight" yaml:"weight"`
-	Tags                map[string]interface{} `json:"tags,omitempty" yaml:"tags,omitempty"`
-	TagGenerators       []TagGenerator         `json:"tagGenerators,omitempty" yaml:"tagGenerators,omitempty"`
-	Inherit             []string               `json:"inherit,omitempty" yaml:"inherit,omitempty"`
+	Weight              int            `json:"weight" yaml:"weight"`
+	Tags                tagMap         `json:"tags,omitempty" yaml:"tags,omitempty"`
+	TagGenerators       []TagGenerator `json:"tagGenerators,omitempty" yaml:"tagGenerators,omitempty"`
+	Inherit             []string       `json:"inherit,omitempty" yaml:"inherit,omitempty"`
 	flags.EmbeddedFlags `json:",inline" yaml:",inline"`
-}
-
-func (ts *TagSet) InsertTags(attr *pdata.AttributeMap) {
-	for key, val := range ts.Tags {
-		switch val := val.(type) {
-		case float64:
-			attr.InsertDouble(key, val)
-		case int:
-			attr.InsertInt(key, int64(val))
-		case string:
-			_, err := strconv.Atoi(val)
-			if err != nil {
-				attr.InsertString(key, val)
-			}
-		case bool:
-			attr.InsertBool(key, val)
-		default:
-			// just insert empty string if it's an unsupported type instead of returning error (todo decide if we want error handling somewhere above this)
-			attr.InsertString(key, "")
-		}
-	}
 }

--- a/collector/generatorreceiver/internal/topology/tag_set_test.go
+++ b/collector/generatorreceiver/internal/topology/tag_set_test.go
@@ -21,7 +21,7 @@ func TestInsertTag(t *testing.T) {
 
 	attr := pdata.NewAttributeMap()
 
-	ts.InsertTags(&attr)
+	ts.Tags.InsertTags(&attr)
 
 	expectedAttr := pdata.NewAttributeMap()
 	expectedAttr.InsertBool("key1", true)


### PR DESCRIPTION
This PR will:
- add support for `kubernetes` section on the `resourceAttrSets` structure
- generated tags will populate `resourceAttrSets.resourceAttrs` for traces generation
- add support for flags on `resourceAttrSets`
- refactor `TagSet.tagMap` to be reusable in `resourceAttrSets` as well


There are still a few things for a next PR:
-  figure out a good to define the values generated, might need a new metric Shape?

Example of this changes:
```yaml
topology:
  services:
    - serviceName: frontend
      ....
      resourceAttrSets:
        - weight: 1
          kubernetes:
            cluster_name: k8s-cluster-1
            request:
              cpu: 0.5
            limit:
              cpu: 0.75
          resourceAttrs:
            cloud.provider: aws
            cloud.region: us-east-1
```