### PR TITLE
embed flags to structures

### DIFF
--- a/collector/generatorreceiver/internal/flags/flag_embed.go
+++ b/collector/generatorreceiver/internal/flags/flag_embed.go
@@ -1,0 +1,21 @@
+package flags
+
+type EmbeddedFlags struct {
+	FlagSet   string `json:"flag_set" yaml:"flag_set"`
+	FlagUnset string `json:"flag_unset" yaml:"flag_unset"`
+}
+
+func (f *EmbeddedFlags) ShouldGenerate(fm *FlagManager) bool {
+	// TODO: use the set flag's _value_... somehow
+	if f.FlagSet != "" {
+		if set := fm.GetFlag(f.FlagSet); !(set != nil && set.Enabled()) {
+			return false
+		}
+	}
+	if f.FlagUnset != "" {
+		if unset := fm.GetFlag(f.FlagUnset); unset != nil && unset.Enabled() {
+			return false
+		}
+	}
+	return true
+}

--- a/collector/generatorreceiver/internal/topology/metric.go
+++ b/collector/generatorreceiver/internal/topology/metric.go
@@ -19,16 +19,15 @@ const (
 )
 
 type Metric struct {
-	Name      string         `json:"name" yaml:"name"`
-	Type      string         `json:"type" yaml:"type"`
-	Min       float64        `json:"min" yaml:"min"`
-	Max       float64        `json:"max" yaml:"max"`
-	Period    *time.Duration `json:"period" yaml:"period"`
-	Offset    *time.Duration `json:"offset" yaml:"offset"`
-	FlagSet   string         `json:"flag_set" yaml:"flag_set"`
-	FlagUnset string         `json:"flag_unset" yaml:"flag_unset"`
-	Tags      map[string]string
-	Shape     Shape `json:"shape" yaml:"shape"`
+	Name                string            `json:"name" yaml:"name"`
+	Type                string            `json:"type" yaml:"type"`
+	Min                 float64           `json:"min" yaml:"min"`
+	Max                 float64           `json:"max" yaml:"max"`
+	Period              *time.Duration    `json:"period" yaml:"period"`
+	Offset              *time.Duration    `json:"offset" yaml:"offset"`
+	Shape               Shape             `json:"shape" yaml:"shape"`
+	Tags                map[string]string `json:"tags" yaml:"tags"`
+	flags.EmbeddedFlags `json:",inline" yaml:",inline"`
 }
 
 func SineValue(phase float64) float64 {
@@ -81,19 +80,4 @@ func (m *Metric) GetValue() float64 {
 	}(phase)
 
 	return m.Min + (m.Max-m.Min)*factor
-}
-
-func (m *Metric) ShouldGenerate(fm *flags.FlagManager) bool {
-	// TODO: use the set flag's _value_... somehow
-	if m.FlagSet != "" {
-		if set := fm.GetFlag(m.FlagSet); !(set != nil && set.Enabled()) {
-			return false
-		}
-	}
-	if m.FlagUnset != "" {
-		if unset := fm.GetFlag(m.FlagUnset); unset != nil && unset.Enabled() {
-			return false
-		}
-	}
-	return true
 }

--- a/collector/generatorreceiver/internal/topology/metric_test.go
+++ b/collector/generatorreceiver/internal/topology/metric_test.go
@@ -17,11 +17,13 @@ func TestMetric_ShouldGenerate(t *testing.T) {
 		{
 			name: "one set flag, enabled",
 			metric: Metric{
-				Name:    "moot",
-				Type:    "Gauge",
-				Min:     0,
-				Max:     100,
-				FlagSet: "yesFlag",
+				Name: "moot",
+				Type: "Gauge",
+				Min:  0,
+				Max:  100,
+				EmbeddedFlags: flags.EmbeddedFlags{
+					FlagSet: "yesFlag",
+				},
 			},
 			enabledFlags: []string{"yesFlag"},
 			want:         true,
@@ -29,11 +31,13 @@ func TestMetric_ShouldGenerate(t *testing.T) {
 		{
 			name: "one set flag, disabled",
 			metric: Metric{
-				Name:    "moot",
-				Type:    "Gauge",
-				Min:     0,
-				Max:     100,
-				FlagSet: "yesFlag",
+				Name: "moot",
+				Type: "Gauge",
+				Min:  0,
+				Max:  100,
+				EmbeddedFlags: flags.EmbeddedFlags{
+					FlagSet: "yesFlag",
+				},
 			},
 			disabledFlags: []string{"yesFlag"},
 			want:          false,
@@ -41,11 +45,13 @@ func TestMetric_ShouldGenerate(t *testing.T) {
 		{
 			name: "one unset flag, disabled",
 			metric: Metric{
-				Name:      "moot",
-				Type:      "Gauge",
-				Min:       0,
-				Max:       100,
-				FlagUnset: "yesFlag",
+				Name: "moot",
+				Type: "Gauge",
+				Min:  0,
+				Max:  100,
+				EmbeddedFlags: flags.EmbeddedFlags{
+					FlagUnset: "yesFlag",
+				},
 			},
 			disabledFlags: []string{"yesFlag"},
 			want:          true,
@@ -53,11 +59,13 @@ func TestMetric_ShouldGenerate(t *testing.T) {
 		{
 			name: "one unset flag, enabled",
 			metric: Metric{
-				Name:      "moot",
-				Type:      "Gauge",
-				Min:       0,
-				Max:       100,
-				FlagUnset: "yesFlag",
+				Name: "moot",
+				Type: "Gauge",
+				Min:  0,
+				Max:  100,
+				EmbeddedFlags: flags.EmbeddedFlags{
+					FlagUnset: "yesFlag",
+				},
 			},
 			enabledFlags: []string{"yesFlag"},
 			want:         false,
@@ -65,12 +73,14 @@ func TestMetric_ShouldGenerate(t *testing.T) {
 		{
 			name: "one set on, one unset off, should generate",
 			metric: Metric{
-				Name:      "moot",
-				Type:      "Gauge",
-				Min:       0,
-				Max:       100,
-				FlagSet:   "yesFlag",
-				FlagUnset: "noFlag",
+				Name: "moot",
+				Type: "Gauge",
+				Min:  0,
+				Max:  100,
+				EmbeddedFlags: flags.EmbeddedFlags{
+					FlagSet:   "yesFlag",
+					FlagUnset: "noFlag",
+				},
 			},
 			enabledFlags:  []string{"yesFlag"},
 			disabledFlags: []string{"noFlag"},
@@ -79,12 +89,14 @@ func TestMetric_ShouldGenerate(t *testing.T) {
 		{
 			name: "one set on, one unset on, should not generate",
 			metric: Metric{
-				Name:      "moot",
-				Type:      "Gauge",
-				Min:       0,
-				Max:       100,
-				FlagSet:   "yesFlag",
-				FlagUnset: "noFlag",
+				Name: "moot",
+				Type: "Gauge",
+				Min:  0,
+				Max:  100,
+				EmbeddedFlags: flags.EmbeddedFlags{
+					FlagSet:   "yesFlag",
+					FlagUnset: "noFlag",
+				},
 			},
 			enabledFlags: []string{"yesFlag", "noFlag"},
 			want:         false,

--- a/collector/generatorreceiver/internal/topology/service_route.go
+++ b/collector/generatorreceiver/internal/topology/service_route.go
@@ -1,6 +1,7 @@
 package topology
 
 import (
+	"github.com/lightstep/lightstep-partner-sdk/collector/generatorreceiver/internal/flags"
 	"math/rand"
 	"time"
 )
@@ -12,8 +13,7 @@ type ServiceRoute struct {
 	LatencyPercentiles    *LatencyPercentiles    `json:"latencyPercentiles" yaml:"latencyPercentiles"`
 	TagSets               []TagSet               `json:"tagSets" yaml:"tagSets"`
 	ResourceAttributeSets []ResourceAttributeSet `json:"resourceAttrSets" yaml:"resourceAttrSets"`
-	FlagSet               string                 `json:"flag_set" yaml:"flag_set"`
-	FlagUnset             string                 `json:"flag_unset" yaml:"flag_unset"`
+	flags.EmbeddedFlags   `json:",inline" yaml:",inline"`
 }
 
 type LatencyPercentiles struct {

--- a/collector/generatorreceiver/internal/topology/tag_set.go
+++ b/collector/generatorreceiver/internal/topology/tag_set.go
@@ -1,18 +1,18 @@
 package topology
 
 import (
+	"github.com/lightstep/lightstep-partner-sdk/collector/generatorreceiver/internal/flags"
 	"strconv"
 
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
 type TagSet struct {
-	Weight        int                    `json:"weight" yaml:"weight"`
-	FlagSet       string                 `json:"flag_set" yaml:"flag_set"`
-	FlagUnset     string                 `json:"flag_unset" yaml:"flag_unset"`
-	Tags          map[string]interface{} `json:"tags,omitempty" yaml:"tags,omitempty"`
-	TagGenerators []TagGenerator         `json:"tagGenerators,omitempty" yaml:"tagGenerators,omitempty"`
-	Inherit       []string               `json:"inherit,omitempty" yaml:"inherit,omitempty"`
+	Weight              int                    `json:"weight" yaml:"weight"`
+	Tags                map[string]interface{} `json:"tags,omitempty" yaml:"tags,omitempty"`
+	TagGenerators       []TagGenerator         `json:"tagGenerators,omitempty" yaml:"tagGenerators,omitempty"`
+	Inherit             []string               `json:"inherit,omitempty" yaml:"inherit,omitempty"`
+	flags.EmbeddedFlags `json:",inline" yaml:",inline"`
 }
 
 func (ts *TagSet) InsertTags(attr *pdata.AttributeMap) {


### PR DESCRIPTION
This wraps the logic of the `flag_set` and `flag_unset` to a new `EmbeddedFlags` struct taking advantage of the `inline` option to make sure that this doesn't add a new nested scope on json or yaml. 

After this, we should be able to easily add the flag logic to any struct by embedding it:
```go
struct {
	....
	flags.EmbeddedFlags `json:",inline" yaml:",inline"`
}
```

This will help adopting flags in https://github.com/lightstep/lightstep-partner-toolkit/pull/23
