### PR TITLE
add support for generating kubernetes memory metrics

### DIFF
--- a/collector/generatorreceiver/internal/topology/kubernetes.go
+++ b/collector/generatorreceiver/internal/topology/kubernetes.go
@@ -9,6 +9,8 @@ import (
 const (
 	defaultTarget = 0.5
 	defaultJitter = 0.4
+
+	megabyte = 1024 * 1024
 )
 
 type Kubernetes struct {
@@ -66,13 +68,25 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 		k.Usage.CPU.TargetPercentage = defaultTarget
 	}
 
+	if k.Usage.Memory.TargetPercentage == 0 {
+		k.Usage.Memory.TargetPercentage = defaultTarget
+	}
+
 	if k.Usage.CPU.Jitter == 0 {
 		k.Usage.CPU.Jitter = defaultJitter
+	}
+
+	if k.Usage.Memory.Jitter == 0 {
+		k.Usage.Memory.Jitter = defaultJitter
 	}
 
 	cpuTarget := k.Request.CPU * k.Usage.CPU.TargetPercentage
 	cpuJitter := k.Usage.CPU.Jitter / 2
 	cpuTotal := k.Limit.CPU * 1.2 // make the node a little bigger than the limit
+
+	memTarget := k.Request.Memory * megabyte * k.Usage.Memory.TargetPercentage
+	memJitter := k.Usage.Memory.Jitter / 2
+	memTotal := k.Limit.Memory * megabyte * 1.2 // make the node a little bigger than the limit
 
 	metrics := []Metric{
 		// kube_pod metrics
@@ -109,6 +123,16 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			},
 		},
 		{
+			Name: "kube_node_status_allocatable",
+			Type: "Gauge",
+			Min:  memTotal, // make the node a little bigger than the limit
+			Max:  memTotal, // make the node a little bigger than the limit
+			Tags: map[string]string{
+				"resource": "memory",
+				"pod":      k.PodName, // used to created multiple time series that will be summed up.
+			},
+		},
+		{
 			Name: "kube_pod_container_resource_requests",
 			Type: "Gauge",
 			Min:  k.Request.CPU,
@@ -121,12 +145,36 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			},
 		},
 		{
+			Name: "kube_pod_container_resource_requests",
+			Type: "Gauge",
+			Min:  k.Request.Memory * megabyte,
+			Max:  k.Request.Memory * megabyte,
+			Tags: map[string]string{
+				"resource":  "memory",
+				"namespace": service.ServiceName,
+				"container": service.ServiceName,
+				"pod":       k.PodName,
+			},
+		},
+		{
 			Name: "kube_pod_container_resource_limits",
 			Type: "Gauge",
 			Min:  k.Limit.CPU,
 			Max:  k.Limit.CPU,
 			Tags: map[string]string{
 				"resource":  "cpu",
+				"namespace": service.ServiceName,
+				"container": service.ServiceName,
+				"pod":       k.PodName,
+			},
+		},
+		{
+			Name: "kube_pod_container_resource_limits",
+			Type: "Gauge",
+			Min:  k.Limit.Memory * megabyte,
+			Max:  k.Limit.Memory * megabyte,
+			Tags: map[string]string{
+				"resource":  "memory",
 				"namespace": service.ServiceName,
 				"container": service.ServiceName,
 				"pod":       k.PodName,
@@ -157,6 +205,30 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 				"cpu":           "0",
 			},
 		},
+
+		{
+			Name:   "node_memory_MemAvailable_bytes",
+			Type:   "Gauge",
+			Min:    math.Max(memTotal-memTarget*(1+memJitter), 0),
+			Max:    math.Min(memTotal-memTarget*(1-memJitter), k.Limit.Memory*megabyte),
+			Shape:  Average,
+			Jitter: k.Usage.Memory.Jitter,
+			Tags: map[string]string{
+				"net.host.name": k.PodName, // for this we assume each pod run on its own node.
+			},
+		},
+
+		{
+			Name:   "node_memory_MemTotal_bytes",
+			Type:   "Gauge",
+			Min:    memTotal,
+			Max:    memTotal,
+			Jitter: k.Usage.Memory.Jitter,
+			Tags: map[string]string{
+				"net.host.name": k.PodName, // for this we assume each pod run on its own node.
+			},
+		},
+
 		// container metrics
 		{
 			Name:   "container_cpu_usage_seconds_total",
@@ -166,6 +238,21 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Max:    math.Min(cpuTarget*(1+cpuJitter), k.Limit.CPU),
 			Shape:  Average,
 			Jitter: k.Usage.CPU.Jitter,
+			Tags: map[string]string{
+				"pod":       k.PodName,
+				"container": service.ServiceName,
+				"image":     service.ServiceName,
+				"namespace": k.Namespace,
+			},
+		},
+		{
+			Name:   "container_memory_working_set_bytes",
+			Type:   "Gauge",
+			Period: &minute,
+			Min:    math.Max(memTarget*(1-memJitter), 0),
+			Max:    math.Min(memTarget*(1+memJitter), k.Limit.Memory*megabyte),
+			Shape:  Average,
+			Jitter: k.Usage.Memory.Jitter,
 			Tags: map[string]string{
 				"pod":       k.PodName,
 				"container": service.ServiceName,

--- a/collector/generatorreceiver/internal/topology/kubernetes.go
+++ b/collector/generatorreceiver/internal/topology/kubernetes.go
@@ -116,7 +116,7 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Name: "kube_node_status_allocatable",
 			Type: "Gauge",
 			Min:  cpuTotal,
-			Max:  cpuTotal, // make the node a little bigger than the limit
+			Max:  cpuTotal,
 			Tags: map[string]string{
 				"resource": "cpu",
 				"pod":      k.PodName, // used to created multiple time series that will be summed up.
@@ -125,8 +125,8 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 		{
 			Name: "kube_node_status_allocatable",
 			Type: "Gauge",
-			Min:  memTotal, // make the node a little bigger than the limit
-			Max:  memTotal, // make the node a little bigger than the limit
+			Min:  memTotal,
+			Max:  memTotal,
 			Tags: map[string]string{
 				"resource": "memory",
 				"pod":      k.PodName, // used to created multiple time series that will be summed up.

--- a/collector/generatorreceiver/topos/hipster_shop.yaml
+++ b/collector/generatorreceiver/topos/hipster_shop.yaml
@@ -13,18 +13,35 @@ topology:
             version: v125
       resourceAttrSets:
         - weight: 1
+          kubernetes:
+            cluster_name: k8s-cluster-1
+            request:
+              cpu: 0.5
+              memory: 2048
+            limit:
+              cpu: 0.75
+              memory: 3072
+            usage:
+              cpu:
+                target: 0.5
+                jitter: 0.5
+              memory:
+                target: 0.6
+                jitter: 0.4
           resourceAttrs:
             cloud.provider: aws
             cloud.region: us-east-1
-            k8s.cluster.name: k8s-cluster-1
-            host.name: ip-172-31-41-139.us-west-2.compute.internal
-            host.id: i-0109aa378a31b4e29
+
         - weight: 1
+          kubernetes:
+            cluster_name: k8s-cluster-1
+            request:
+              cpu: 0.5
+            limit:
+              cpu: 0.75
           resourceAttrs:
             cloud.provider: aws
             cloud.region: us-west-2
-            k8s.cluster.name: k8s-cluster-1
-            host.name: ip-172-31-41-140.us-west-2.compute.internal
       metrics:
         - name: another_gauge
           type: Gauge
@@ -34,6 +51,11 @@ topology:
           flag_unset: frontend_doom
           tags:
             something: good
+        - name: please_counter
+          type: Counter
+          max: 10000
+          min: 1000
+          period: 2m
         - name: another_gauge
           type: Gauge
           max: 20000
@@ -51,69 +73,6 @@ topology:
           flag_set: frontend_doom.phase_2
           tags:
             something: worse
-        - name: node_cpu_seconds_total
-          type: Sum
-          max: 100
-          min: 0
-          period: 2m
-          shape: sawtooth
-          tags:
-            host.name: frontend.internal
-            net.host.name: frontend.internal
-            cpu: "1"
-            namespace: hipster-shop
-        - name: node_memory_Active_bytes
-          type: Gauge
-          max: 50000
-          min: 0
-          period: 5m
-          shape: sawtooth
-          tags:
-            host.name: frontend.internal
-            net.host.name: frontend.internal
-            namespace: hipster-shop
-        - name: node_memory_MemTotal_bytes
-          type: Gauge
-          max: 2147483648
-          min: 1000000000
-          period: 5m
-          shape: sawtooth
-          tags:
-            host.name: frontend.internal
-            net.host.name: frontend.internal
-            namespace: hipster-shop
-        - name: node_memory_MemAvailable_bytes
-          type: Gauge
-          max: 2147483648
-          min: 20000
-          period: 5m
-          shape: sawtooth
-          flag_unset: currencyservice_oom.phase_2
-          tags:
-            host.name: frontend.internal
-            net.host.name: frontend.internal
-            namespace: hipster-shop
-        - name: node_memory_MemAvailable_bytes
-          type: Gauge
-          max: 200000
-          min: 20000
-          period: 5m
-          shape: sawtooth
-          flag_set: currencyservice_oom.phase_2
-          tags:
-            host.name: frontend.internal
-            net.host.name: frontend.internal
-            namespace: hipster-shop
-        - name: container_cpu_usage_seconds_total
-          type: Sum
-          max: 200
-          min: 0
-          period: 2m
-          shape: triangle
-          tags:
-            host.name: frontend.internal
-            cpu: "1"
-            namespace: hipster-shop  
       routes:
         - route: /product
           downstreamCalls:
@@ -165,19 +124,23 @@ topology:
             - region
       resourceAttrSets:
         - weight: 1
+          kubernetes:
+            cluster_name: k8s-cluster-2
+            request:
+              cpu: 0.5
+              memory: 512
+            limit:
+              cpu: 1
+              memory: 1024
           resourceAttrs:
             cloud.provider: azure
             cloud.region: Central-US
-            k8s.cluster.name: k8s-cluster-2
             host.type: t3.medium
-            host.name: productcatalogservice-d847fdcf5-j6s2f
         - weight: 1
           resourceAttrs:
             cloud.provider: azure
             cloud.region: West-US
-            k8s.cluster.name: k8s-cluster-2
             host.type: t3.medium
-            host.name: productcatalogservice-6b654dbf57-zq8dt
       routes:
         - route: /GetProducts
           downstreamCalls: {}
@@ -202,17 +165,29 @@ topology:
             region: us-east-1
       resourceAttrSets:
         - weight: 1
+          kubernetes:
+            cluster_name: k8s-cluster-3
+            request:
+              cpu: 0.5
+              memory: 512
+            limit:
+              cpu: 1
+              memory: 1024
           resourceAttrs:
             cloud.provider: aws
             cloud.region: us-west-2
-            k8s.cluster.name: k8s-cluster-3
-            host.name: recommendationservice-6b654dbf57-zq8dt
         - weight: 1
+          kubernetes:
+            cluster_name: k8s-cluster-3
+            request:
+              cpu: 0.5
+              memory: 512
+            limit:
+              cpu: 1
+              memory: 1024
           resourceAttrs:
             cloud.provider: aws
             cloud.region: us-west-1
-            k8s.cluster.name: k8s-cluster-3
-            host.name: recommendationservice-d847fdcf5-j6s2f
       routes:
         - route: /GetRecommendations
           downstreamCalls:
@@ -229,6 +204,14 @@ topology:
           flag_set: runs_on_azure
       resourceAttrSets:
         - weight: 1
+          kubernetes:
+            cluster_name: k8s-cluster-4
+            request:
+              cpu: 1
+              memory: 512
+            limit:
+              cpu: 2
+              memory: 1024
           resourceAttrs:
             host.name: cartservice-hostname
       routes:
@@ -242,8 +225,14 @@ topology:
             region: us-east-1
       resourceAttrSets:
         - weight: 1
-          resourceAttrs:
-            host.name: checkoutservice-hostname
+          kubernetes:
+            cluster_name: k8s-cluster-1
+            request:
+              cpu: 0.5
+              memory: 512
+            limit:
+              cpu: 1
+              memory: 1024
       routes:
         - route: /PlaceOrder
           downstreamCalls:
@@ -267,6 +256,14 @@ topology:
             region: us-east-1
       resourceAttrSets:
         - weight: 1
+          kubernetes:
+            cluster_name: k8s-cluster-6
+            request:
+              cpu: 0.5
+              memory: 512
+            limit:
+              cpu: 1
+              memory: 1024
           resourceAttrs:
             host.name: paymentservice-hostname
       routes:
@@ -284,6 +281,14 @@ topology:
             region: us-east-1
       resourceAttrSets:
         - weight: 1
+          kubernetes:
+            cluster_name: k8s-cluster-7
+            request:
+              cpu: 0.5
+              memory: 512
+            limit:
+              cpu: 1
+              memory: 1024
           resourceAttrs:
             host.name: shippingservice-hostname
       routes:
@@ -305,6 +310,14 @@ topology:
             region: us-east-1
       resourceAttrSets:
         - weight: 1
+          kubernetes:
+            cluster_name: k8s-cluster-8
+            request:
+              cpu: 0.5
+              memory: 512
+            limit:
+              cpu: 1
+              memory: 1024
           resourceAttrs:
             host.name: emailservice-hostname
       routes:
@@ -330,41 +343,16 @@ topology:
             region: us-east-1
       resourceAttrSets:
         - weight: 1
+          kubernetes:
+            cluster_name: k8s-cluster-9
+            request:
+              cpu: 0.5
+              memory: 512
+            limit:
+              cpu: 1
+              memory: 1024
           resourceAttrs:
             host.name: currencyservice-hostname
-      metrics:
-        - name: node_memory_MemTotal_bytes
-          type: Gauge
-          max: 2147483648
-          min: 2000000000
-          period: 5m
-          shape: sawtooth    
-          tags:
-            host.name: currencyservice.internal
-            net.host.name: currencyservice.internal
-            namespace: hipster-shop
-        - name: node_memory_MemAvailable_bytes
-          type: Gauge
-          max: 1500000000
-          min: 1000000000
-          flag_set: currencyservice_oom.default
-          period: 5m
-          shape: sawtooth
-          tags:
-            host.name: currencyservice.internal
-            net.host.name: currencyservice.internal
-            namespace: hipster-shop
-        - name: node_memory_MemAvailable_bytes
-          type: Gauge
-          flag_set: currencyservice_oom.phase_1
-          max: 10000000
-          min: 2000000
-          period: 5m
-          shape: sawtooth
-          tags:
-            host.name: currencyservice.internal
-            net.host.name: currencyservice.internal
-            namespace: hipster-shop
       routes:
         - route: /GetConversion
           downstreamCalls:
@@ -383,6 +371,14 @@ topology:
           region: us-east-1
       resourceAttrSets:
         - weight: 1
+          kubernetes:
+            cluster_name: k8s-cluster-10
+            request:
+              cpu: 0.5
+              memory: 512
+            limit:
+              cpu: 1
+              memory: 1024
           resourceAttrs:
             host.name: adservice-hostname
       routes:


### PR DESCRIPTION
What it does?
---
- Adds support for generating k8s memory metrics.
- Updates `hipster-shop.yaml` topology with kubernetes metrics.


Examples
---
Cluster dashboard:
<img width="1880" alt="image" src="https://user-images.githubusercontent.com/7898464/182907468-bbd598e3-b5b8-47ee-8792-936d94ee2fce.png">

Workload dashboard:
<img width="1239" alt="image" src="https://user-images.githubusercontent.com/7898464/182907506-8a06f3e7-efa3-42e8-8ee3-2972eee56281.png">


