### PR TITLE
Flag support for root routes

### DIFF
--- a/collector/generatorreceiver/generator_receiver.go
+++ b/collector/generatorreceiver/generator_receiver.go
@@ -146,6 +146,7 @@ func (g generatorReceiver) Start(ctx context.Context, host component.Host) error
 			done := make(chan bool)
 			svc := r.Service
 			route := r.Route
+			r := r
 			go func() {
 				g.logger.Info("generating traces", zap.String("service", svc), zap.String("route", route))
 				traceGen := generator.NewTraceGenerator(topoFile.Topology, g.randomSeed, svc, route)
@@ -154,8 +155,10 @@ func (g generatorReceiver) Start(ctx context.Context, host component.Host) error
 					case <-done:
 						return
 					case _ = <-traceTicker.C:
-						traces := traceGen.Generate(time.Now().UnixNano())
-						_ = g.traceConsumer.ConsumeTraces(context.Background(), *traces)
+						if r.ShouldGenerate() {
+							traces := traceGen.Generate(time.Now().UnixNano())
+							_ = g.traceConsumer.ConsumeTraces(context.Background(), *traces)
+						}
 					}
 				}
 			}()

--- a/collector/generatorreceiver/internal/topology/file.go
+++ b/collector/generatorreceiver/internal/topology/file.go
@@ -12,9 +12,10 @@ type File struct {
 }
 
 type RootRoute struct {
-	Service       string `json:"service" yaml:"service"`
-	Route         string `json:"route" yaml:"route"`
-	TracesPerHour int    `json:"tracesPerHour" yaml:"tracesPerHour"`
+	Service             string `json:"service" yaml:"service"`
+	Route               string `json:"route" yaml:"route"`
+	TracesPerHour       int    `json:"tracesPerHour" yaml:"tracesPerHour"`
+	flags.EmbeddedFlags `json:",inline" yaml:",inline"`
 }
 
 func (file *File) ValidateRootRoutes() error {


### PR DESCRIPTION
This PR provides flag support for root routes. Below is an example where throughput (i.e. `tracesPerHour`) for root route `frontend: /checkout` varies based on whether flag `throughput_spike` is enabled or not. Therefore, the resulting Lightstep chart shows the number of spans with service = `frontend` and operation = `/checkout` toggling between high and low every 5 minutes. Because route `paymentservice: /CreditCardInfo` is only downstream of root route `frontend: /checkout`, its span count chart shows the same behavior.

**YAML:** (assume that the rest of the config is the same as `hipster_shop.yaml`)
```
flags:
 - name: throughput_spike
    cron:
      start: "0,10,20,30,40,50 * * * *"
      end: "5,15,25,35,45,55 * * * *"
rootRoutes:
  - service: frontend
    route: /checkout
    tracesPerHour: 480
    flag_set: throughput_spike
  - service: frontend
    route: /checkout
    tracesPerHour: 120
    flag_unset: throughput_spike
```

**Resulting spans:**

<img width="1341" alt="Screen Shot 2022-08-13 at 12 21 08 PM" src="https://user-images.githubusercontent.com/47488945/184504331-2ced0fa6-2964-4f35-bb04-3c9cd2f18c89.png">

