### PR TITLE
support weight between span attributes

### DIFF
--- a/collector/generatorreceiver/internal/topology/tag_set.go
+++ b/collector/generatorreceiver/internal/topology/tag_set.go
@@ -5,7 +5,7 @@ import (
 )
 
 type TagSet struct {
-	Weight              int            `json:"weight" yaml:"weight"`
+	Weight              float64        `json:"weight" yaml:"weight"`
 	Tags                TagMap         `json:"tags,omitempty" yaml:"tags,omitempty"`
 	TagGenerators       []TagGenerator `json:"tagGenerators,omitempty" yaml:"tagGenerators,omitempty"`
 	Inherit             []string       `json:"inherit,omitempty" yaml:"inherit,omitempty"`


### PR DESCRIPTION
This PR provides support for weights by configuration of different error rates. By specifying different error rates (weights) under each tagSet in `dev.yaml`, these are emitted according to their configuration. Here is an example of where error rates for `/product` varies based on whether `error: true` or not with the same weight. 

Resulting error:
<img width="768" alt="image" src="https://user-images.githubusercontent.com/15680283/184692039-59a86e8c-fb0f-4516-a88a-c556ce08f713.png">
