### PR TITLE
(generatorreceiver) Updates to latency percentiles calculations

### DIFF
--- a/collector/generatorreceiver/internal/generator/trace_generator.go
+++ b/collector/generatorreceiver/internal/generator/trace_generator.go
@@ -54,11 +54,11 @@ func (g *TraceGenerator) genSpanId() pdata.SpanID {
 	return pdata.NewSpanID(traceId)
 }
 
-func (g *TraceGenerator) Generate(startTimeMicros int64) *pdata.Traces {
+func (g *TraceGenerator) Generate(startTimeNanos int64) *pdata.Traces {
 	rootService := g.topology.GetServiceTier(g.service)
 	traces := pdata.NewTraces()
 
-	g.createSpanForServiceRouteCall(&traces, rootService, g.route, startTimeMicros, g.genTraceId(), pdata.NewSpanID([8]byte{0x0}))
+	g.createSpanForServiceRouteCall(&traces, rootService, g.route, startTimeNanos, g.genTraceId(), pdata.NewSpanID([8]byte{0x0}))
 
 	return &traces
 }
@@ -80,7 +80,7 @@ func pickBasedOnWeight(tagSets []topology.TagSet) topology.TagSet {
 	return topology.TagSet{}
 }
 
-func (g *TraceGenerator) createSpanForServiceRouteCall(traces *pdata.Traces, serviceTier *topology.ServiceTier, routeName string, startTimeMicros int64, traceId pdata.TraceID, parentSpanId pdata.SpanID) *pdata.Span {
+func (g *TraceGenerator) createSpanForServiceRouteCall(traces *pdata.Traces, serviceTier *topology.ServiceTier, routeName string, startTimeNanos int64, traceId pdata.TraceID, parentSpanId pdata.SpanID) *pdata.Span {
 	serviceTier.Random = g.random
 	route := serviceTier.GetRoute(routeName)
 
@@ -136,24 +136,28 @@ func (g *TraceGenerator) createSpanForServiceRouteCall(traces *pdata.Traces, ser
 		}
 	}
 
-	maxEndTime := startTimeMicros
+	maxEndTime := startTimeNanos
 	for s, r := range route.DownstreamCalls {
-		var childStartTimeMicros int64
+		var childStartTimeNanos = startTimeNanos
 		if route.LatencyPercentiles != nil {
-			childStartTimeMicros = startTimeMicros + int64(route.LatencyPercentiles.Sample())
+			childStartTimeNanos += route.LatencyPercentiles.Sample()
 		} else {
-			childStartTimeMicros = startTimeMicros + (g.random.Int63n(route.MaxLatencyMillis * 1000000))
+			childStartTimeNanos += g.random.Int63n(route.MaxLatencyMillis * 1000000)
 		}
 		childSvc := g.topology.GetServiceTier(s)
 
-		g.createSpanForServiceRouteCall(traces, childSvc, r, childStartTimeMicros, traceId, newSpanId)
-		maxEndTime = Max(maxEndTime, childStartTimeMicros)
+		g.createSpanForServiceRouteCall(traces, childSvc, r, childStartTimeNanos, traceId, newSpanId)
+		maxEndTime = Max(maxEndTime, childStartTimeNanos)
 	}
 
 	// todo: ownDuration should also be influenced by percentiles or not?
 	// note - changing this number seems to effect very little
-	ownDuration := g.random.Int63n(route.MaxLatencyMillis * 1000000)
-	span.SetStartTimestamp(pdata.NewTimestampFromTime(time.Unix(0, startTimeMicros)))
+	maxLatency := route.MaxLatencyMillis * 1000000
+	if route.LatencyPercentiles != nil {
+		maxLatency = route.LatencyPercentiles.Sample()
+	}
+	ownDuration := g.random.Int63n(maxLatency)
+	span.SetStartTimestamp(pdata.NewTimestampFromTime(time.Unix(0, startTimeNanos)))
 	span.SetEndTimestamp(pdata.NewTimestampFromTime(time.Unix(0, maxEndTime+ownDuration)))
 	g.sequenceNumber = g.sequenceNumber + 1
 	return &span

--- a/collector/generatorreceiver/internal/topology/latency_percentiles.go
+++ b/collector/generatorreceiver/internal/topology/latency_percentiles.go
@@ -33,13 +33,10 @@ func (l *LatencyPercentiles) Sample() int64 {
 	case genNumber <= 0.5:
 		return uniform(l.durations.p0, l.durations.p50)
 	case genNumber <= 0.95:
-		// 1% of requests
 		return uniform(l.durations.p50, l.durations.p95)
 	case genNumber <= 0.99:
-		// 5% of requests
 		return uniform(l.durations.p95, l.durations.p99)
 	case genNumber <= 0.999:
-		// 50% of requests
 		return uniform(l.durations.p99, l.durations.p999)
 	default:
 		return uniform(l.durations.p999, l.durations.p100)

--- a/collector/generatorreceiver/internal/topology/service_route.go
+++ b/collector/generatorreceiver/internal/topology/service_route.go
@@ -3,6 +3,7 @@ package topology
 import (
 	"fmt"
 	"github.com/lightstep/lightstep-partner-sdk/collector/generatorreceiver/internal/flags"
+	"math/rand"
 )
 
 type ServiceRoute struct {
@@ -33,7 +34,7 @@ func (r *ServiceRoute) validate(t Topology) error {
 	}
 
 	if r.LatencyPercentiles == nil && r.MaxLatencyMillis <= 0 {
-		return fmt.Errorf("must have a positive, non-zero maxLatencyMillis defined")
+		return fmt.Errorf("must have either latencyPercentiles or positive, non-zero maxLatencyMillis defined")
 	}
 	return nil
 }
@@ -47,4 +48,12 @@ func (r *ServiceRoute) load(route string) error {
 		}
 	}
 	return nil
+}
+
+func (r *ServiceRoute) SampleLatency() int64 {
+	if r.LatencyPercentiles == nil {
+		return rand.Int63n(r.MaxLatencyMillis * 1000000)
+	} else {
+		return r.LatencyPercentiles.Sample()
+	}
 }

--- a/collector/generatorreceiver/internal/topology/service_route.go
+++ b/collector/generatorreceiver/internal/topology/service_route.go
@@ -32,7 +32,7 @@ func (r *ServiceRoute) validate(t Topology) error {
 		}
 	}
 
-	if r.MaxLatencyMillis <= 0 {
+	if r.LatencyPercentiles == nil && r.MaxLatencyMillis <= 0 {
 		return fmt.Errorf("must have a positive, non-zero maxLatencyMillis defined")
 	}
 	return nil

--- a/collector/generatorreceiver/topos/hipster_shop.yaml
+++ b/collector/generatorreceiver/topos/hipster_shop.yaml
@@ -142,7 +142,13 @@ topology:
             productcatalogservice: /GetProducts
             recommendationservice: /GetRecommendations
             adservice: /AdRequest
-          maxLatencyMillis: 200
+          latencyPercentiles:
+            p0: 25ms
+            p50: 75ms
+            p95: 100ms
+            p99: 120ms
+            p99.9: 150ms
+            p100: 200ms
           tagSets:
             - weight: 1
               tags:
@@ -161,7 +167,13 @@ topology:
           downstreamCalls:
             cartservice: /GetCart
             recommendationservice: /GetRecommendations
-          maxLatencyMillis: 100
+          latencyPercentiles:
+            p0: 25ms
+            p50: 75ms
+            p95: 100ms
+            p99: 120ms
+            p99.9: 150ms
+            p100: 200ms
         /checkout:
           downstreamCalls:
             checkoutservice: /PlaceOrder


### PR DESCRIPTION
This PR (mostly written by @njvrzm) does the following:
- Removes the multiply-by-1000 logic from `LatencyPercentiles.Sample()`
  - Had originated from a misnaming - the `Generate()` function was being called with `traces := traceGen.Generate(time.Now().UnixNano())` but the parameter was named `startTimeMicros`. 
- Fixes latency calculation logic (and validation) so that `maxLatencyMillis` isn't required if `latencyPercentiles` is present.
- Adds some `latencyPercentiles` examples to `hipster_shop.yaml`.
- Addresses issue where parent spans could have end times before their child spans' end times.
  - If a route has downstream calls, its end timestamp is now set to the timestamp of whichever child has the latest end timestamp.