### PR TITLE
add support for kubernetes restarts

### DIFF
--- a/collector/generatorreceiver/internal/generator/metric_generator.go
+++ b/collector/generatorreceiver/internal/generator/metric_generator.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"github.com/lightstep/lightstep-partner-sdk/collector/generatorreceiver/internal/topology"
-	"math/rand"
 	"time"
 
 	"go.opentelemetry.io/collector/model/pdata"
@@ -10,17 +9,15 @@ import (
 
 type MetricGenerator struct {
 	metricCount int
-	random      *rand.Rand
 }
 
-func NewMetricGenerator(r *rand.Rand) *MetricGenerator {
+func NewMetricGenerator() *MetricGenerator {
 	return &MetricGenerator{
 		metricCount: 0,
-		random:      r,
 	}
 }
 
-func (g *MetricGenerator) Generate(metric topology.Metric, serviceName string) (pdata.Metrics, bool) {
+func (g *MetricGenerator) Generate(metric *topology.Metric, serviceName string) (pdata.Metrics, bool) {
 	metrics := pdata.NewMetrics()
 
 	if !metric.ShouldGenerate() {
@@ -36,8 +33,8 @@ func (g *MetricGenerator) Generate(metric topology.Metric, serviceName string) (
 		m.SetDataType(pdata.MetricDataTypeGauge)
 		dp := m.Gauge().DataPoints().AppendEmpty()
 		dp.SetTimestamp(pdata.NewTimestampFromTime(time.Now()))
-		dp.SetDoubleVal(metric.GetValue(g.random))
-		for k, v := range metric.Tags {
+		dp.SetDoubleVal(metric.GetValue())
+		for k, v := range metric.GetTags() {
 			dp.Attributes().UpsertString(k, v)
 		}
 	} else if metric.Type == "Sum" {
@@ -49,8 +46,8 @@ func (g *MetricGenerator) Generate(metric topology.Metric, serviceName string) (
 		dp := m.Sum().DataPoints().AppendEmpty()
 		dp.SetStartTimestamp(pdata.NewTimestampFromTime(time.Now()))
 		dp.SetTimestamp(pdata.NewTimestampFromTime(time.Now()))
-		dp.SetDoubleVal(metric.GetValue(g.random))
-		for k, v := range metric.Tags {
+		dp.SetDoubleVal(metric.GetValue())
+		for k, v := range metric.GetTags() {
 			dp.Attributes().UpsertString(k, v)
 		}
 	}

--- a/collector/generatorreceiver/internal/generator/trace_generator.go
+++ b/collector/generatorreceiver/internal/generator/trace_generator.go
@@ -98,7 +98,7 @@ func (g *TraceGenerator) createSpanForServiceRouteCall(traces *pdata.Traces, ser
 	resourceAttributeSet := serviceTier.GetResourceAttributeSet()
 	if resourceAttributeSet != nil {
 		attrs := resource.Attributes()
-		resourceAttributeSet.ResourceAttributes.InsertTags(&attrs)
+		resourceAttributeSet.GetAttributes().InsertTags(&attrs)
 	}
 
 	ils := rspan.InstrumentationLibrarySpans().AppendEmpty()

--- a/collector/generatorreceiver/internal/topology/kubernetes.go
+++ b/collector/generatorreceiver/internal/topology/kubernetes.go
@@ -93,7 +93,6 @@ func (k *Kubernetes) ReplaceTags(tags map[string]string) map[string]string {
 	defer k.mutex.Unlock()
 
 	replaced := make(map[string]string, len(tags))
-
 	for key, value := range tags {
 		switch value {
 		case Pod:

--- a/collector/generatorreceiver/internal/topology/kubernetes.go
+++ b/collector/generatorreceiver/internal/topology/kubernetes.go
@@ -3,6 +3,7 @@ package topology
 import (
 	"math"
 	"math/rand"
+	"sync"
 	"time"
 )
 
@@ -12,6 +13,15 @@ const (
 	defaultDisk    = 100
 	defaultNetwork = 800
 	megabyte       = 1024 * 1024
+
+	// Templated variables, these will get replaced with real values at metric generation with ReplaceTags.
+
+	Pod        = "$pod"
+	Service    = "$service"
+	Namespace  = "$namespace"
+	Container  = "$container"
+	Cluster    = "$cluster"
+	ReplicaSet = "$replicaset"
 )
 
 type Kubernetes struct {
@@ -19,16 +29,23 @@ type Kubernetes struct {
 	Request     Resource `json:"request" yaml:"request"`
 	Limit       Resource `json:"limit" yaml:"limit"`
 	Usage       Usage    `json:"usage" yaml:"usage"`
+	Restart     Restart  `json:"restart" yaml:"restart"`
 
-	ReplicaSetName string
-	Namespace      string
-	PodName        string
-	Container      string
+	mutex          sync.Mutex
+	Service        string `json:"-" yaml:"-"`
+	ReplicaSetName string `json:"-" yaml:"-"`
+	Namespace      string `json:"-" yaml:"-"`
+	PodName        string `json:"-" yaml:"-"`
+	Container      string `json:"-" yaml:"-"`
 }
 
 type Resource struct {
 	CPU    float64 `json:"cpu" yaml:"cpu"`
 	Memory float64 `json:"memory" yaml:"memory"`
+}
+
+type Restart struct {
+	Every time.Duration `json:"every" yaml:"every"`
 }
 
 type Usage struct {
@@ -43,14 +60,25 @@ type ResourceUsage struct {
 	Jitter float64 `json:"jitter" yaml:"jitter"`
 }
 
-func (k *Kubernetes) CreatePod(service ServiceTier) {
-	k.ReplicaSetName = service.ServiceName + "-" + generateK8sName(10)
+func (k *Kubernetes) CreatePod(serviceName string) {
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
+	k.ReplicaSetName = serviceName + "-" + generateK8sName(10)
 	k.PodName = k.ReplicaSetName + "-" + generateK8sName(5)
-	k.Namespace = service.ServiceName
-	k.Container = service.ServiceName
+	k.Namespace = serviceName
+	k.Container = serviceName
+	k.Service = serviceName
+}
+
+func (k *Kubernetes) RestartPod() {
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
+	k.PodName = k.ReplicaSetName + "-" + generateK8sName(5)
 }
 
 func (k *Kubernetes) GetK8sTags() map[string]string {
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	// ref: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/k8s.md
 	return map[string]string{
 		"k8s.cluster.name":   k.ClusterName,
@@ -60,7 +88,35 @@ func (k *Kubernetes) GetK8sTags() map[string]string {
 	}
 }
 
-func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
+func (k *Kubernetes) ReplaceTags(tags map[string]string) map[string]string {
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
+
+	replaced := make(map[string]string, len(tags))
+
+	for key, value := range tags {
+		switch value {
+		case Pod:
+			replaced[key] = k.PodName
+		case Service:
+			replaced[key] = k.Service
+		case Namespace:
+			replaced[key] = k.Namespace
+		case Container:
+			replaced[key] = k.Container
+		case Cluster:
+			replaced[key] = k.ClusterName
+		case ReplicaSet:
+			replaced[key] = k.ReplicaSetName
+		default:
+			replaced[key] = value
+		}
+	}
+
+	return replaced
+}
+
+func (k *Kubernetes) GenerateMetrics() []Metric {
 	if k.ClusterName == "" {
 		return nil
 	}
@@ -113,6 +169,13 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 	networkTarget := k.Usage.Network.Target
 	networkJitter := k.Usage.Network.Jitter / 2
 
+	restart := 1.
+	memoryShape := Average
+	if k.Restart.Every != 0 {
+		restart = 0
+		memoryShape = Leaking
+	}
+
 	metrics := []Metric{
 		// kube_pod metrics
 		{
@@ -122,7 +185,7 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Max:  1,
 			Tags: map[string]string{
 				"phase": "Running",
-				"pod":   k.PodName,
+				"pod":   Pod,
 			},
 		},
 		{
@@ -131,9 +194,9 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Min:  1,
 			Max:  1,
 			Tags: map[string]string{
-				"pod":        k.PodName,
-				"namespace":  service.ServiceName,
-				"owner_name": k.ReplicaSetName,
+				"pod":        Pod,
+				"namespace":  Namespace,
+				"owner_name": ReplicaSet,
 				"owner_kind": "ReplicaSet",
 			},
 		},
@@ -144,7 +207,7 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Max:  cpuTotal,
 			Tags: map[string]string{
 				"resource": "cpu",
-				"pod":      k.PodName, // used to created multiple time series that will be summed up.
+				"pod":      Pod, // used to created multiple time series that will be summed up.
 			},
 		},
 		{
@@ -154,7 +217,7 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Max:  memTotal,
 			Tags: map[string]string{
 				"resource": "memory",
-				"pod":      k.PodName, // used to created multiple time series that will be summed up.
+				"pod":      Pod, // used to created multiple time series that will be summed up.
 			},
 		},
 		{
@@ -164,9 +227,9 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Max:  k.Request.CPU,
 			Tags: map[string]string{
 				"resource":  "cpu",
-				"namespace": service.ServiceName,
-				"container": service.ServiceName,
-				"pod":       k.PodName,
+				"namespace": Namespace,
+				"container": Container,
+				"pod":       Pod,
 			},
 		},
 		{
@@ -176,9 +239,9 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Max:  k.Request.Memory * megabyte,
 			Tags: map[string]string{
 				"resource":  "memory",
-				"namespace": service.ServiceName,
-				"container": service.ServiceName,
-				"pod":       k.PodName,
+				"namespace": Namespace,
+				"container": Container,
+				"pod":       Pod,
 			},
 		},
 		{
@@ -188,9 +251,9 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Max:  k.Limit.CPU,
 			Tags: map[string]string{
 				"resource":  "cpu",
-				"namespace": service.ServiceName,
-				"container": service.ServiceName,
-				"pod":       k.PodName,
+				"namespace": Namespace,
+				"container": Container,
+				"pod":       Pod,
 			},
 		},
 		{
@@ -200,9 +263,9 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Max:  k.Limit.Memory * megabyte,
 			Tags: map[string]string{
 				"resource":  "memory",
-				"namespace": service.ServiceName,
-				"container": service.ServiceName,
-				"pod":       k.PodName,
+				"namespace": Namespace,
+				"container": Container,
+				"pod":       Pod,
 			},
 		},
 		// node metrics
@@ -213,7 +276,7 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Max:  k.Limit.CPU * 1.2,
 			Tags: map[string]string{
 				"resource":      "cpu",
-				"net.host.name": k.PodName, // for this we assume each pod run on its own node.
+				"net.host.name": Pod, // for this we assume each pod run on its own node.
 				"cpu":           "0",
 			},
 		},
@@ -227,7 +290,7 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Jitter: k.Usage.CPU.Jitter,
 			Tags: map[string]string{
 				"resource":      "cpu",
-				"net.host.name": k.PodName, // for this we assume each pod run on its own node.
+				"net.host.name": Pod, // for this we assume each pod run on its own node.
 				"cpu":           "0",
 			},
 		},
@@ -240,7 +303,7 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Shape:  Average,
 			Jitter: k.Usage.Memory.Jitter,
 			Tags: map[string]string{
-				"net.host.name": k.PodName, // for this we assume each pod run on its own node.
+				"net.host.name": Pod, // for this we assume each pod run on its own node.
 			},
 		},
 
@@ -251,7 +314,7 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Max:    memTotal,
 			Jitter: k.Usage.Memory.Jitter,
 			Tags: map[string]string{
-				"net.host.name": k.PodName, // for this we assume each pod run on its own node.
+				"net.host.name": Pod, // for this we assume each pod run on its own node.
 			},
 		},
 
@@ -264,10 +327,10 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Shape:  Average,
 			Jitter: k.Usage.CPU.Jitter,
 			Tags: map[string]string{
-				"pod":       k.PodName,
-				"container": service.ServiceName,
-				"image":     service.ServiceName,
-				"namespace": k.Namespace,
+				"pod":       Pod,
+				"container": Container,
+				"image":     Service,
+				"namespace": Namespace,
 			},
 		},
 		{
@@ -280,9 +343,9 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Tags: map[string]string{
 				"job":          "kubelet",
 				"metrics_path": "/metrics/cadvisor",
-				"container":    service.ServiceName,
+				"container":    Container,
 				"device":       "/dev/sda",
-				"namespace":    k.Namespace,
+				"namespace":    Namespace,
 			},
 		},
 		{
@@ -295,9 +358,9 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Tags: map[string]string{
 				"job":          "kubelet",
 				"metrics_path": "/metrics/cadvisor",
-				"container":    service.ServiceName,
+				"container":    Container,
 				"device":       "/dev/sda",
-				"namespace":    k.Namespace,
+				"namespace":    Namespace,
 			},
 		},
 		{
@@ -310,9 +373,9 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Tags: map[string]string{
 				"job":          "kubelet",
 				"metrics_path": "/metrics/cadvisor",
-				"container":    service.ServiceName,
+				"container":    Container,
 				"device":       "/dev/sda",
-				"namespace":    k.Namespace,
+				"namespace":    Namespace,
 			},
 		},
 		{
@@ -325,24 +388,25 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Tags: map[string]string{
 				"job":          "kubelet",
 				"metrics_path": "/metrics/cadvisor",
-				"container":    service.ServiceName,
+				"container":    Container,
 				"device":       "/dev/sda",
-				"namespace":    k.Namespace,
+				"namespace":    Namespace,
 			},
 		},
 		{
 			Name:   "container_memory_working_set_bytes",
 			Type:   "Gauge",
 			Period: &minute,
-			Min:    math.Max(memTarget*(1-memJitter), 0),
-			Max:    math.Min(memTarget*(1+memJitter), k.Limit.Memory*megabyte),
-			Shape:  Average,
+			// If k.restart.every is set, min should be 0 and max should be k.Limit.memory
+			Min:    math.Max(memTarget*(1-memJitter)*restart, 0),
+			Max:    math.Min(memTarget*(1+memJitter)+k.Limit.Memory*megabyte*(1-restart), k.Limit.Memory*megabyte),
+			Shape:  memoryShape,
 			Jitter: k.Usage.Memory.Jitter,
 			Tags: map[string]string{
-				"pod":       k.PodName,
-				"container": service.ServiceName,
-				"image":     service.ServiceName,
-				"namespace": k.Namespace,
+				"pod":       Pod,
+				"container": Container,
+				"image":     Service,
+				"namespace": Namespace,
 			},
 		},
 		{
@@ -353,7 +417,7 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Shape:  Average,
 			Jitter: k.Usage.Network.Jitter,
 			Tags: map[string]string{
-				"image": service.ServiceName,
+				"image": Service,
 			},
 		},
 		{
@@ -364,7 +428,7 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Shape:  Average,
 			Jitter: k.Usage.Network.Jitter,
 			Tags: map[string]string{
-				"image": service.ServiceName,
+				"image": Service,
 			},
 		},
 		{
@@ -375,7 +439,7 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Shape:  Average,
 			Jitter: k.Usage.Network.Jitter,
 			Tags: map[string]string{
-				"image": service.ServiceName,
+				"image": Service,
 			},
 		},
 		{
@@ -386,9 +450,13 @@ func (k *Kubernetes) GenerateMetrics(service ServiceTier) []Metric {
 			Shape:  Average,
 			Jitter: k.Usage.Network.Jitter,
 			Tags: map[string]string{
-				"image": service.ServiceName,
+				"image": Service,
 			},
 		},
+	}
+
+	for i := range metrics {
+		metrics[i].Kubernetes = k
 	}
 
 	return metrics

--- a/collector/generatorreceiver/internal/topology/kubernetes.go
+++ b/collector/generatorreceiver/internal/topology/kubernetes.go
@@ -32,11 +32,12 @@ type Kubernetes struct {
 	Restart     Restart  `json:"restart" yaml:"restart"`
 
 	mutex          sync.Mutex
-	Service        string `json:"-" yaml:"-"`
-	ReplicaSetName string `json:"-" yaml:"-"`
-	Namespace      string `json:"-" yaml:"-"`
-	PodName        string `json:"-" yaml:"-"`
-	Container      string `json:"-" yaml:"-"`
+	StartTime      time.Time `json:"-" yaml:"-"`
+	Service        string    `json:"-" yaml:"-"`
+	ReplicaSetName string    `json:"-" yaml:"-"`
+	Namespace      string    `json:"-" yaml:"-"`
+	PodName        string    `json:"-" yaml:"-"`
+	Container      string    `json:"-" yaml:"-"`
 }
 
 type Resource struct {
@@ -63,6 +64,7 @@ type ResourceUsage struct {
 func (k *Kubernetes) CreatePod(serviceName string) {
 	k.mutex.Lock()
 	defer k.mutex.Unlock()
+	k.StartTime = time.Now()
 	k.ReplicaSetName = serviceName + "-" + generateK8sName(10)
 	k.PodName = k.ReplicaSetName + "-" + generateK8sName(5)
 	k.Namespace = serviceName
@@ -73,6 +75,7 @@ func (k *Kubernetes) CreatePod(serviceName string) {
 func (k *Kubernetes) RestartPod() {
 	k.mutex.Lock()
 	defer k.mutex.Unlock()
+	k.StartTime = time.Now()
 	k.PodName = k.ReplicaSetName + "-" + generateK8sName(5)
 }
 

--- a/collector/generatorreceiver/internal/topology/kubernetes_test.go
+++ b/collector/generatorreceiver/internal/topology/kubernetes_test.go
@@ -1,0 +1,42 @@
+package topology
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestReplaceTags(t *testing.T) {
+	k := &Kubernetes{
+		PodName:        "testapp-abbab-abb",
+		Service:        "testapp-service",
+		Namespace:      "testapp-namespace",
+		Container:      "testapp-container",
+		ClusterName:    "testapp-cluster",
+		ReplicaSetName: "testapp-replica",
+	}
+
+	tags := map[string]string{
+		"my_pod":       Pod,
+		"my_service":   Service,
+		"my_namespace": Namespace,
+		"my_container": Container,
+		"my_cluster":   Cluster,
+		"my_replica":   ReplicaSet,
+		"my_key":       "my_value",
+	}
+
+	tags = k.ReplaceTags(tags)
+
+	require.Equal(t,
+		map[string]string{
+			"my_pod":       "testapp-abbab-abb",
+			"my_service":   "testapp-service",
+			"my_namespace": "testapp-namespace",
+			"my_container": "testapp-container",
+			"my_cluster":   "testapp-cluster",
+			"my_replica":   "testapp-replica",
+			"my_key":       "my_value",
+		},
+		tags,
+	)
+}

--- a/collector/generatorreceiver/internal/topology/metric.go
+++ b/collector/generatorreceiver/internal/topology/metric.go
@@ -39,7 +39,7 @@ func (ls *leakingShape) GetValue(phase float64) (float64, float64) {
 		ls.lastPod = ls.kubernetes.PodName
 		ls.increase = 0
 	} else {
-		ls.increase = ls.increase + float64(DefaultMetricTickerPeriod)/float64(ls.kubernetes.Restart.Every)
+		ls.increase = ls.increase + float64(DefaultMetricTickerPeriod)/float64(ls.kubernetes.Restart.Every)/2
 	}
 
 	v, _ := ls.average.GetValue(phase)

--- a/collector/generatorreceiver/internal/topology/resource_attribute_set.go
+++ b/collector/generatorreceiver/internal/topology/resource_attribute_set.go
@@ -1,10 +1,25 @@
 package topology
 
-import "github.com/lightstep/lightstep-partner-sdk/collector/generatorreceiver/internal/flags"
+import (
+	"github.com/lightstep/lightstep-partner-sdk/collector/generatorreceiver/internal/flags"
+)
 
 type ResourceAttributeSet struct {
 	Weight              int        `json:"weight" yaml:"weight"`
 	Kubernetes          Kubernetes `json:"kubernetes" yaml:"kubernetes"`
 	ResourceAttributes  TagMap     `json:"resourceAttrs,omitempty" yaml:"resourceAttrs,omitempty"`
 	flags.EmbeddedFlags `json:",inline" yaml:",inline"`
+}
+
+func (r *ResourceAttributeSet) GetAttributes() *TagMap {
+	tm := make(TagMap)
+	for k, v := range r.ResourceAttributes {
+		tm[k] = v
+	}
+
+	for k, v := range r.Kubernetes.GetK8sTags() {
+		tm[k] = v
+	}
+
+	return &tm
 }

--- a/collector/generatorreceiver/internal/topology/service_tier.go
+++ b/collector/generatorreceiver/internal/topology/service_tier.go
@@ -25,10 +25,10 @@ func (st *ServiceTier) GetResourceAttributeSet() *ResourceAttributeSet {
 	if len(st.ResourceAttributeSets) == 0 {
 		return nil
 	}
-	var enabledResources []ResourceAttributeSet
-	for _, resource := range st.ResourceAttributeSets {
-		if resource.ShouldGenerate() {
-			enabledResources = append(enabledResources, resource)
+	var enabledResources []*ResourceAttributeSet
+	for i := range st.ResourceAttributeSets {
+		if st.ResourceAttributeSets[i].ShouldGenerate() {
+			enabledResources = append(enabledResources, &st.ResourceAttributeSets[i])
 		}
 	}
 
@@ -38,7 +38,7 @@ func (st *ServiceTier) GetResourceAttributeSet() *ResourceAttributeSet {
 
 	// TODO: also support resource attributes on routes
 	// TODO: support weight
-	return &enabledResources[st.Random.Intn(len(enabledResources))]
+	return enabledResources[st.Random.Intn(len(enabledResources))]
 }
 
 func (st *ServiceTier) GetRoute(routeName string) *ServiceRoute {

--- a/collector/generatorreceiver/topos/hipster_shop.yaml
+++ b/collector/generatorreceiver/topos/hipster_shop.yaml
@@ -37,8 +37,12 @@ topology:
             cluster_name: k8s-cluster-1
             request:
               cpu: 0.5
+              memory: 2048
             limit:
               cpu: 0.75
+              memory: 3072
+            restart:
+              every: 5m
           resourceAttrs:
             cloud.provider: aws
             cloud.region: us-west-2


### PR DESCRIPTION
This PR:
- Adds support for simulating pod memory leak based on some time defined on configurations
- ResourceAttributes are now dynamic, for getting an updated tag set when a "restart" happen
- Metric `Shape` is now backed by a `ShapeInterface` that is used for generating values and a `Leaking` Shape is added that keeps track of "restarts"


Restart configuration example that will restart the POD every 5 min:
```yaml
      resourceAttrSets:
        - weight: 1
          kubernetes:
            cluster_name: k8s-cluster-1
            request:
              cpu: 0.5
              memory: 2048
            limit:
              cpu: 0.75
              memory: 3072
            restart:
              every: 5m
```

In this case, one of the pod is "healthy" and another one is in a OOM crash loopback, we can then add some flags to have this behavior happen from time to time.
<img width="1267" alt="image" src="https://user-images.githubusercontent.com/7898464/185468421-4eb46a48-a90a-409f-8c55-56d28d11f83c.png">