### PR TITLE
Generatorv2 - add iOS and android adil

### DIFF
--- a/collector/generatorreceiver/topos/hipster_shop.yaml
+++ b/collector/generatorreceiver/topos/hipster_shop.yaml
@@ -496,6 +496,60 @@ topology:
         /Ad:
           downstreamCalls: {}
           maxLatencyMillis: 500
+    iOS:
+      resourceAttrSets:
+        - weight: 1 
+          resourceAttrs:
+            instrument.name: lighstep
+            http.method: POST
+            customer: hipcore
+            client.platform: iOS 
+      metrics:
+        - name: requests
+          type: Sum
+          max: 400
+          min: 0
+          period: 5m
+          shape: triangle
+      routes:
+        /api/make-payment:
+          downstreamCalls:
+            iOS: /api/submit-payment
+          maxLatencyMillis: 100
+        /api/submit-payment:
+          downstreamCalls:
+           iOS: /api/payment-status
+          maxLatencyMillis: 100
+        /api/payment-status:
+          downstreamCalls: {}
+          maxLatencyMillis: 100
+    android:
+      resourceAttrs:
+        - weight: 1 
+          resourceAttrs:
+            instrument.name: lighstep
+            http.method: POST
+            customer: hipcore
+            client.platform: android
+      metrics:
+        - name: requests
+          type: Sum
+          max: 400
+          min: 0
+          period: 5m
+          shape: triangle
+      routes:
+        /api/make-payment:
+          downstreamCalls:
+            android: /api/submit-payment
+          maxLatencyMillis: 100
+        /api/submit-payment:
+          downstreamCalls:
+           android: /api/payment-status
+          maxLatencyMillis: 100
+        /api/payment-status:
+          downstreamCalls: {}
+          maxLatencyMillis: 100               
 
 flags:
   # This is a cron-style flag
@@ -558,4 +612,10 @@ rootRoutes:
     tracesPerHour: 200
   - service: frontend
     route: /checkout
+    tracesPerHour: 480
+  - service: iOS
+    route: /api/make-payment
+    tracesPerHour: 480
+  - service: android  
+    route: /api/make-payment
     tracesPerHour: 480


### PR DESCRIPTION
<img width="2262" alt="Screen Shot 2022-08-18 at 12 50 52 PM" src="https://user-images.githubusercontent.com/87725682/185485793-6b6d618c-b176-4a4f-bc98-9ec0f82da9f9.png">
<img width="2261" alt="Screen Shot 2022-08-18 at 12 51 01 PM" src="https://user-images.githubusercontent.com/87725682/185485799-6049a704-19c7-415b-8043-1a06ff96d5d0.png">


For the sake of demo I nested what would normally be parallel routes for `downStreamCalls`. Easy quick for the upcoming PR to address multiple downStreamCalls

