### PR TITLE
Allow variable latencies by flag

### DIFF
--- a/collector/generatorreceiver/generator_receiver.go
+++ b/collector/generatorreceiver/generator_receiver.go
@@ -44,11 +44,12 @@ func (g generatorReceiver) loadTopoFile(topoInline string, path string) (topoFil
 			return nil, err
 		}
 	}
+	flags.Manager.LoadFlags(topoFile.Flags, g.logger)
+
 	err = topoFile.Topology.Load()
 	if err != nil {
 		return nil, err
 	}
-	flags.Manager.LoadFlags(topoFile.Flags, g.logger)
 
 	return topoFile, nil
 }

--- a/collector/generatorreceiver/internal/flags/flag_embed.go
+++ b/collector/generatorreceiver/internal/flags/flag_embed.go
@@ -22,7 +22,11 @@ func (f *EmbeddedFlags) ShouldGenerate() bool {
 	return true
 }
 
-func (f *EmbeddedFlags) Validate() error {
+func (f *EmbeddedFlags) IsDefault() bool {
+	return f.FlagSet == "" && f.FlagUnset == ""
+}
+
+func (f *EmbeddedFlags) ValidateFlags() error {
 	if f.FlagSet != "" && Manager.GetFlag(f.FlagSet) == nil {
 		return fmt.Errorf("flag %v does not exist", f.FlagSet)
 	}

--- a/collector/generatorreceiver/internal/flags/flag_test.go
+++ b/collector/generatorreceiver/internal/flags/flag_test.go
@@ -111,7 +111,7 @@ func TestEmbeddedFlags_Validate(t *testing.T) {
 			}
 			Manager.LoadFlags(theFlags, zap.NewNop())
 
-			err := tt.embeddedFlags.Validate()
+			err := tt.embeddedFlags.ValidateFlags()
 			if err != nil && !tt.error {
 				assert.Fail(t, fmt.Sprintf("did not expect validation error but got: %v", err))
 			}

--- a/collector/generatorreceiver/internal/topology/service_route.go
+++ b/collector/generatorreceiver/internal/topology/service_route.go
@@ -10,7 +10,7 @@ type ServiceRoute struct {
 	Route                 string                 `json:"route" yaml:"route"`
 	DownstreamCalls       map[string]string      `json:"downstreamCalls,omitempty" yaml:"downstreamCalls,omitempty"`
 	MaxLatencyMillis      int64                  `json:"maxLatencyMillis" yaml:"maxLatencyMillis"`
-	LatencyPercentiles    *LatencyPercentiles    `json:"latencyPercentiles" yaml:"latencyPercentiles"`
+	LatencyConfigs        LatencyConfigs         `json:"latencyConfigs" yaml:"latencyConfigs"`
 	TagSets               []TagSet               `json:"tagSets" yaml:"tagSets"`
 	ResourceAttributeSets []ResourceAttributeSet `json:"resourceAttrSets" yaml:"resourceAttrSets"`
 	flags.EmbeddedFlags   `json:",inline" yaml:",inline"`
@@ -18,7 +18,7 @@ type ServiceRoute struct {
 }
 
 func (r *ServiceRoute) validate(t Topology) error {
-	err := r.Validate()
+	err := r.ValidateFlags()
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func (r *ServiceRoute) validate(t Topology) error {
 		}
 	}
 
-	if r.LatencyPercentiles == nil && r.MaxLatencyMillis <= 0 {
+	if r.LatencyConfigs == nil && r.MaxLatencyMillis <= 0 {
 		return fmt.Errorf("must have either latencyPercentiles or positive, non-zero maxLatencyMillis defined")
 	}
 	return nil
@@ -41,19 +41,37 @@ func (r *ServiceRoute) validate(t Topology) error {
 
 func (r *ServiceRoute) load(route string) error {
 	r.Route = route
-	if r.LatencyPercentiles != nil {
-		err := r.LatencyPercentiles.loadDurations()
+	if r.LatencyConfigs == nil {
+		if r.MaxLatencyMillis == 0 {
+			return fmt.Errorf("route must include maxLatencyMillis or latencyConfigs")
+		} else {
+			return nil
+		}
+	}
+	hasDefault := false
+	for _, cfg := range r.LatencyConfigs {
+		err := cfg.loadDurations()
 		if err != nil {
 			return fmt.Errorf("error parsing latencyPercentiles: %v", err)
 		}
+		err = cfg.ValidateFlags()
+		if err != nil {
+			return err
+		}
+		if cfg.IsDefault() {
+			hasDefault = true
+		}
+	}
+	if !hasDefault {
+		return fmt.Errorf("latencyConfigs must include a default (no flag_set or flag_unset)")
 	}
 	return nil
 }
 
 func (r *ServiceRoute) SampleLatency() int64 {
-	if r.LatencyPercentiles == nil {
+	if r.LatencyConfigs == nil {
 		return rand.Int63n(r.MaxLatencyMillis * 1000000)
 	} else {
-		return r.LatencyPercentiles.Sample()
+		return r.LatencyConfigs.Sample()
 	}
 }

--- a/collector/generatorreceiver/internal/topology/service_route.go
+++ b/collector/generatorreceiver/internal/topology/service_route.go
@@ -59,11 +59,14 @@ func (r *ServiceRoute) load(route string) error {
 			return err
 		}
 		if cfg.IsDefault() {
+			if hasDefault {
+				return fmt.Errorf("latencyConfigs must include exactly one default config (no flag_set or flag_unset)")
+			}
 			hasDefault = true
 		}
 	}
 	if !hasDefault {
-		return fmt.Errorf("latencyConfigs must include a default (no flag_set or flag_unset)")
+		return fmt.Errorf("latencyConfigs must include exactly one default config (no flag_set or flag_unset)")
 	}
 	return nil
 }

--- a/collector/generatorreceiver/internal/topology/service_tier.go
+++ b/collector/generatorreceiver/internal/topology/service_tier.go
@@ -47,7 +47,7 @@ func (st *ServiceTier) GetRoute(routeName string) *ServiceRoute {
 
 func (st *ServiceTier) Validate(topology Topology) error {
 	for _, m := range st.Metrics {
-		err := m.Validate()
+		err := m.ValidateFlags()
 		if err != nil {
 			return fmt.Errorf("error with metric %s in service %s: %v", m.Name, st.ServiceName, err)
 		}
@@ -59,13 +59,13 @@ func (st *ServiceTier) Validate(topology Topology) error {
 		}
 	}
 	for _, t := range st.TagSets {
-		err := t.Validate()
+		err := t.ValidateFlags()
 		if err != nil {
 			return fmt.Errorf("error with tagSets in service %s: %v", st.ServiceName, err)
 		}
 	}
 	for _, ra := range st.ResourceAttributeSets {
-		err := ra.Validate()
+		err := ra.ValidateFlags()
 		if err != nil {
 			return fmt.Errorf("error with resourceAttributeSets in service %s: %v", st.ServiceName, err)
 		}

--- a/collector/generatorreceiver/topos/hipster_shop.yaml
+++ b/collector/generatorreceiver/topos/hipster_shop.yaml
@@ -48,13 +48,20 @@ topology:
             productcatalogservice: /GetProducts
             recommendationservice: /GetRecommendations
             adservice: /AdRequest
-          latencyPercentiles:
-            p0: 25ms
-            p50: 75ms
-            p95: 100ms
-            p99: 120ms
-            p99.9: 150ms
-            p100: 200ms
+          latencyConfigs:
+            - flag_set: frontend_errors
+              p0: 25ms
+              p50: 185ms
+              p95: 250ms
+              p99: 300ms
+              p99.9: 400ms
+              p100: 600ms
+            - p0: 25ms
+              p50: 75ms
+              p95: 100ms
+              p99: 120ms
+              p99.9: 150ms
+              p100: 200ms
           tagSets:
             - weight: 1
               tags:
@@ -73,13 +80,13 @@ topology:
           downstreamCalls:
             cartservice: /GetCart
             recommendationservice: /GetRecommendations
-          latencyPercentiles:
-            p0: 25ms
-            p50: 75ms
-            p95: 100ms
-            p99: 120ms
-            p99.9: 150ms
-            p100: 200ms
+          latencyConfigs:
+            - p0: 25ms
+              p50: 75ms
+              p95: 100ms
+              p99: 120ms
+              p99.9: 150ms
+              p100: 200ms
         /checkout:
           downstreamCalls:
             checkoutservice: /PlaceOrder


### PR DESCRIPTION
This adds support for changing latency based on flag, to enable latency-driven scenarios. `latencyConfigs`, if present, must contain a list of `latencyPercentiles`; at least one must have no flags set. This will be used as the default when none of the others `ShouldGenerate()`.